### PR TITLE
Add Public Holiday Controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @Tag(name="Public Holiday info")
 @Slf4j
 @RestController
-@RequestMapping("/api/publicholidays/get")
+@RequestMapping("/api/publicholidays")
 public class PublicHolidaysController {
     ObjectMapper mapper = new ObjectMapper();
 

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidaysController.java
@@ -1,9 +1,40 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Tag(name="Public Holiday info")
+@Slf4j
 @RestController
+@RequestMapping("/api/publicholidays/get")
 public class PublicHolidaysController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    PublicHolidayQueryService publicHolidayQueryService;
+
+    @Operation(summary = "Gets public holidays for a country and year", description = "JSON return format documented here: https://date.nager.at/api/v2/publicholidays/{year}/{countryCode}")
+    @GetMapping("/get")
+    public ResponseEntity<String> getPublicHolidays(
+        @Parameter(name="year", description="what year for public holidays", example="2021") @RequestParam String year,
+        @Parameter(name="countryCode", description="code for country", example="US") @RequestParam String countryCode
+    ) throws JsonProcessingException {
+        log.info("getPublicHolidays: year={} countryCode={}", year, countryCode);
+        String result = publicHolidayQueryService.getJSON(year, countryCode);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidayControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/PublicHolidayControllerTests.java
@@ -1,0 +1,60 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.PublicHolidayQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = PublicHolidaysController.class)
+public class PublicHolidayControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  PublicHolidayQueryService mockPublicHolidayQueryService;
+
+
+  @Test
+  public void test_getPublicHolidays() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String year = "2022";
+    String countryCode = "US";
+    when(mockPublicHolidayQueryService.getJSON(eq(year),eq(countryCode))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/publicholidays/get?year=%s&countryCode=%s",year,countryCode);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/publicholidays/get` that can be used to get the public holidays in a specific country for a specific year

Test Link: http://team01-kateunger-dev.dokku-11.cs.ucsb.edu/swagger-ui/index.html

Closes #11 